### PR TITLE
Implements mkdir with options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SOURCES
     src/assets/usage.cpp
     src/command_map.cpp
     src/ls.cpp
+    src/mkdir.cpp
     src/process_args.cpp
     src/string_parser.cpp
 )

--- a/src/mkdir.cpp
+++ b/src/mkdir.cpp
@@ -1,0 +1,160 @@
+#include <VFMS/command/realize_command.hpp>
+#include <VFMS/command_map.hpp>
+#include <VFMS/vfs.hpp>
+
+#include <vector>
+#include <string>
+#include <unordered_map>
+
+#include <boost/algorithm/string.hpp>
+
+namespace vfms
+{
+    namespace assets
+    {
+        extern void send_error(std::string error_for);
+        extern void usage(std::string use_for);
+    }
+
+    extern struct command_line::command_stat* process_args(std::vector<std::string> args);
+
+    // Currently we support only help formats
+    enum mkdir_options_long
+    {
+        help,
+    };
+
+    // Mapping help tag with enum
+    std::unordered_map<std::string, mkdir_options_long> mkdir_long_tags =
+    {
+        {"help", mkdir_options_long::help},
+    };
+
+    struct mkdir
+    {
+        // store the info related to the command
+        struct command_line::command_stat* obj;
+
+        // Storing current folder
+        vfs* current_folder;
+
+        // long tags
+        bool is_help;
+
+        mkdir(vfs* current_folder, struct command_line::command_stat* obj)
+        {
+            this -> obj = obj;
+            this -> current_folder = current_folder;
+
+            this -> is_help = false;
+        }
+
+        void show_help()
+        {
+            std::cout << "mkdir: usage\n"
+                        "mkdir [OPTION]... [FILE]...\n"
+                        "Creates Directory at the listed location.\n"
+                        "\nOptions:\n"
+                        "\t--help\t\t\tDisplay help text\n";
+            
+            return;
+        }
+
+        void process()
+        {
+            if(this -> is_help)
+            {
+                this -> show_help();
+                return;
+            }
+
+            if(obj -> dir_name.size() != 0)
+            {
+                vfs* get_to_folder =
+                    current_folder -> go_to(obj -> dir_name.at(0), true);
+                if(get_to_folder == current_folder)
+                {
+                    // Make directory in the current folder
+                    current_folder -> create_folder(obj -> dir_name.at(obj -> dir_name.size() - 1));
+                } else if(get_to_folder != nullptr)
+                {
+                    // Make directory in a different folder
+                    get_to_folder -> create_folder(obj -> dir_name.at(obj -> dir_name.size() - 1));
+                }
+            }
+            else
+            {
+                // The command was not provided correctly
+                assets::send_error("mkdir");
+                assets::usage("mkdir");
+                return;
+            }
+        }
+    };
+
+    void exec_mkdir(std::vector<std::string> args, vfs* current_folder)
+    {   
+        struct command_line::command_stat* obj = process_args(args);
+
+        if(obj == nullptr)
+        {
+                std::string command = "mkdir";
+                assets::send_error(command);
+                assets::usage(command);
+
+                return;
+        }
+
+        struct mkdir mkdir_object(current_folder, obj);
+
+        if(mkdir_object.obj == nullptr)
+        {
+            // The command was not provided correctly
+            assets::send_error(args.at(0));
+            assets::usage(args.at(0));
+            return;
+        }
+        else
+        {
+            if(!mkdir_object.obj -> partial_help_tag.empty())
+            {
+                // Some short tags can be used in conjunction. We need
+                // to distinguish them form each other.
+                std::vector<std::string> short_tags = get_short_tags(mkdir_object.obj -> partial_help_tag, std::ref(mkdir_object));
+            
+                if(short_tags.empty())
+                    return;
+            }
+
+            // initializing the enum object
+            mkdir_options_long tag;
+
+            try
+            {   if(!obj -> complete_help_tag.empty())
+                {   
+                    for(auto&& arg: mkdir_object.obj -> complete_help_tag)
+                    {
+                        
+                        tag = mkdir_long_tags.at(arg);
+
+                        switch(tag) 
+                        {
+                            case help:
+                                mkdir_object.is_help = true;
+                                break;
+                        }
+                    }
+                }    
+            } catch(...)
+            {
+                std::string command = "mkdir";
+                assets::send_error(command);
+                assets::usage(command);
+
+                return;
+            }
+
+            mkdir_object.process();
+        }
+    }
+}

--- a/src/mkdir.cpp
+++ b/src/mkdir.cpp
@@ -118,12 +118,9 @@ namespace vfms
         {
             if(!mkdir_object.obj -> partial_help_tag.empty())
             {
-                // Some short tags can be used in conjunction. We need
-                // to distinguish them form each other.
-                std::vector<std::string> short_tags = get_short_tags(mkdir_object.obj -> partial_help_tag, std::ref(mkdir_object));
-            
-                if(short_tags.empty())
-                    return;
+                assets::send_error((std::string)"mkdir");
+                assets::usage((std::string)"mkdir");
+                return;
             }
 
             // initializing the enum object

--- a/src/process_args.cpp
+++ b/src/process_args.cpp
@@ -18,7 +18,7 @@ namespace vfms
             std::string help_tag = "-";
             std::string escape_character = "\\";
 
-            /* There are can be 3 type of arguments.
+            /* There can be 3 type of arguments.
                 1. Directories/file
                 2. partial helper tag (ex: ls -la)
                 3. Complete helper tags (ex: ls --help)
@@ -29,9 +29,13 @@ namespace vfms
                 if(args.at(i).at(0) == '-')
                 {
                     if(args.at(i).at(1) != '-')
+                    {
                         stats -> partial_help_tag.append(args.at(i).substr(1, args.at(i).size() - 1));
+                    }
                     else
+                    {
                         stats -> complete_help_tag.push_back(args.at(i).substr(2, args.at(i).size() - 2));
+                    }
                 }
                 // It is a directory
                 else
@@ -47,13 +51,13 @@ namespace vfms
                         // Get complete path to the file/directory
                         while(args.at(i).at(args.at(i).size() - 1) == '\\')
                         {
-                            dir_name.append(args.at(i).substr(0, args.at(i).size() - 2));
+                            dir_name.append(args.at(i).substr(0, args.at(i).size() - 1));
                             dir_name.append(" ");
                             i++;
                         }
                         // Complete path to the file/directory
-                        dir_name = dir_name.substr(0, dir_name.size() - 2);
-                        i--;    // Since we increment i, we need decrement to get back to actual i
+                        dir_name.append(args.at(i));
+                        i++;    // Passing to the next arg
                     }
 
                     stats -> dir_name.push_back(dir_name);

--- a/src/string_parser.cpp
+++ b/src/string_parser.cpp
@@ -11,6 +11,7 @@ namespace vfms
 {
     extern std::unordered_map<std::string, commands> valid_commands;
     extern void exec_ls(std::vector<std::string> args, vfs* current_folder);
+    extern void exec_mkdir(std::vector<std::string> args, vfs* current_folder);
 
     string_parser::string_parser(std::vector<std::string> arguments)
     {
@@ -54,32 +55,6 @@ namespace vfms
             // 'mkdir' can create multiple folders at a single time
             case mkdir:
                 exec_mkdir(this -> arguments, current_folder);
-                if(this -> arguments.size() == 1)
-                {
-                    // Incorrect usage of mkdir. Raise an error.
-                    std::cerr << "Wrong use of command 'mkdir'.\n"
-                        "Usage: mkdir dir1 dir2 dir3" << std::endl;
-
-                } else
-                {
-                    for(int i = 1; i != this -> arguments.size(); ++i)
-                    {
-                        // Move to the specified directory. If there is 
-                        // none then raise alert that the folder 
-                        // does not exists.
-                        vfms::vfs* get_to_folder =
-                            current_folder -> go_to(this -> arguments[i], true);
-
-                        if(get_to_folder == current_folder){
-                            // Make directory in the current folder
-                            current_folder -> create_folder(this -> arguments[i]);
-                        } else if(get_to_folder != nullptr)
-                        {
-                            // Make directory in a different folder
-                            get_to_folder -> create_folder(this -> arguments[i]);
-                        }
-                    }
-                }
                 // Return back the current folder
                 return current_folder;
             

--- a/src/string_parser.cpp
+++ b/src/string_parser.cpp
@@ -53,6 +53,7 @@ namespace vfms
 
             // 'mkdir' can create multiple folders at a single time
             case mkdir:
+                exec_mkdir(this -> arguments, current_folder);
                 if(this -> arguments.size() == 1)
                 {
                     // Incorrect usage of mkdir. Raise an error.


### PR DESCRIPTION
This PR adds the options `--help` for `mkdir`. `mkdir` now supports multiple word directory that can be created with standard Linux like command. Eg:

```
$ mkdir abc\ def
```

will create a directory `abc def` in the current folder.