### PR TITLE
Implements cd for VFMS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ include_directories(${CMAKE_SOURCE_DIR})
 set(SOURCES
     src/assets/error.cpp
     src/assets/usage.cpp
+    src/cd.cpp
     src/command_map.cpp
     src/ls.cpp
     src/mkdir.cpp

--- a/src/cd.cpp
+++ b/src/cd.cpp
@@ -71,15 +71,11 @@ namespace vfms
             if(obj -> dir_name.size() != 0)
             {
                 vfs* get_to_folder =
-                    current_folder -> go_to(obj -> dir_name.at(0), true);
-                if(get_to_folder == current_folder)
+                    current_folder -> go_to(obj -> dir_name.at(0));
+                if(get_to_folder != nullptr)
                 {
-                    // Make directory in the current folder
-                    current_folder -> create_folder(obj -> dir_name.at(obj -> dir_name.size() - 1));
-                } else if(get_to_folder != nullptr)
-                {
-                    // Make directory in a different folder
-                    get_to_folder -> create_folder(obj -> dir_name.at(obj -> dir_name.size() - 1));
+                    // Make directory in a different folderget_to_folder -> create_folder(obj -> dir_name.at(obj -> dir_name.size() - 1));
+                    this -> current_folder = get_to_folder;
                 }
             }
             else
@@ -92,7 +88,7 @@ namespace vfms
         }
     };
 
-    void exec_cd(std::vector<std::string> args, vfs* current_folder)
+    vfs* exec_cd(std::vector<std::string> args, vfs* current_folder)
     {   
         struct command_line::command_stat* obj = process_args(args);
 
@@ -102,7 +98,7 @@ namespace vfms
                 assets::send_error(command);
                 assets::usage(command);
 
-                return;
+                return nullptr;
         }
 
         struct cd cd_object(current_folder, obj);
@@ -112,7 +108,7 @@ namespace vfms
             // The command was not provided correctly
             assets::send_error(args.at(0));
             assets::usage(args.at(0));
-            return;
+            return nullptr;
         }
         else
         {
@@ -120,7 +116,7 @@ namespace vfms
             {
                 assets::send_error((std::string)"cd");
                 assets::usage((std::string)"cd");
-                return;
+                return nullptr;
             }
 
             // initializing the enum object
@@ -148,10 +144,11 @@ namespace vfms
                 assets::send_error(command);
                 assets::usage(command);
 
-                return;
+                return nullptr;
             }
 
             cd_object.process();
+            return cd_object.current_folder;
         }
     }
 }

--- a/src/cd.cpp
+++ b/src/cd.cpp
@@ -1,0 +1,157 @@
+#include <VFMS/command/realize_command.hpp>
+#include <VFMS/command_map.hpp>
+#include <VFMS/vfs.hpp>
+
+#include <vector>
+#include <string>
+#include <unordered_map>
+
+#include <boost/algorithm/string.hpp>
+
+namespace vfms
+{
+    namespace assets
+    {
+        extern void send_error(std::string error_for);
+        extern void usage(std::string use_for);
+    }
+
+    extern struct command_line::command_stat* process_args(std::vector<std::string> args);
+
+    // Currently we support only help formats
+    enum cd_options_long
+    {
+        help,
+    };
+
+    // Mapping help tag with enum
+    std::unordered_map<std::string, cd_options_long> cd_long_tags =
+    {
+        {"help", cd_options_long::help},
+    };
+
+    struct cd
+    {
+        // store the info related to the command
+        struct command_line::command_stat* obj;
+
+        // Storing current folder
+        vfs* current_folder;
+
+        // long tags
+        bool is_help;
+
+        cd(vfs* current_folder, struct command_line::command_stat* obj)
+        {
+            this -> obj = obj;
+            this -> current_folder = current_folder;
+
+            this -> is_help = false;
+        }
+
+        void show_help()
+        {
+            std::cout << "cd: usage\n"
+                        "cd [OPTION]... [FILE]...\n"
+                        "Creates Directory at the listed location.\n"
+                        "\nOptions:\n"
+                        "\t--help\t\t\tDisplay help text\n";
+            
+            return;
+        }
+
+        void process()
+        {
+            if(this -> is_help)
+            {
+                this -> show_help();
+                return;
+            }
+
+            if(obj -> dir_name.size() != 0)
+            {
+                vfs* get_to_folder =
+                    current_folder -> go_to(obj -> dir_name.at(0), true);
+                if(get_to_folder == current_folder)
+                {
+                    // Make directory in the current folder
+                    current_folder -> create_folder(obj -> dir_name.at(obj -> dir_name.size() - 1));
+                } else if(get_to_folder != nullptr)
+                {
+                    // Make directory in a different folder
+                    get_to_folder -> create_folder(obj -> dir_name.at(obj -> dir_name.size() - 1));
+                }
+            }
+            else
+            {
+                // The command was not provided correctly
+                assets::send_error("cd");
+                assets::usage("cd");
+                return;
+            }
+        }
+    };
+
+    void exec_cd(std::vector<std::string> args, vfs* current_folder)
+    {   
+        struct command_line::command_stat* obj = process_args(args);
+
+        if(obj == nullptr)
+        {
+                std::string command = "cd";
+                assets::send_error(command);
+                assets::usage(command);
+
+                return;
+        }
+
+        struct cd cd_object(current_folder, obj);
+
+        if(cd_object.obj == nullptr)
+        {
+            // The command was not provided correctly
+            assets::send_error(args.at(0));
+            assets::usage(args.at(0));
+            return;
+        }
+        else
+        {
+            if(!cd_object.obj -> partial_help_tag.empty())
+            {
+                assets::send_error((std::string)"cd");
+                assets::usage((std::string)"cd");
+                return;
+            }
+
+            // initializing the enum object
+            cd_options_long tag;
+
+            try
+            {   if(!obj -> complete_help_tag.empty())
+                {   
+                    for(auto&& arg: cd_object.obj -> complete_help_tag)
+                    {
+                        
+                        tag = cd_long_tags.at(arg);
+
+                        switch(tag) 
+                        {
+                            case help:
+                                cd_object.is_help = true;
+                                break;
+                        }
+                    }
+                }    
+            } catch(...)
+            {
+                std::string command = "cd";
+                assets::send_error(command);
+                assets::usage(command);
+
+                return;
+            }
+
+            cd_object.process();
+        }
+    }
+}

--- a/src/string_parser.cpp
+++ b/src/string_parser.cpp
@@ -10,6 +10,7 @@
 namespace vfms
 {
     extern std::unordered_map<std::string, commands> valid_commands;
+    extern void exec_cd(std::vector<std::string> args, vfs* current_folder);
     extern void exec_ls(std::vector<std::string> args, vfs* current_folder);
     extern void exec_mkdir(std::vector<std::string> args, vfs* current_folder);
 
@@ -61,6 +62,8 @@ namespace vfms
 
             // 'cd' command allows to enter and leave directories
             case cd:
+                exec_cd(this -> arguments, current_folder);
+
                 if(this -> arguments.size() == 2)
                 {
                     vfms::vfs* temp = current_folder;

--- a/src/string_parser.cpp
+++ b/src/string_parser.cpp
@@ -10,7 +10,7 @@
 namespace vfms
 {
     extern std::unordered_map<std::string, commands> valid_commands;
-    extern void exec_cd(std::vector<std::string> args, vfs* current_folder);
+    extern vfs* exec_cd(std::vector<std::string> args, vfs* current_folder);
     extern void exec_ls(std::vector<std::string> args, vfs* current_folder);
     extern void exec_mkdir(std::vector<std::string> args, vfs* current_folder);
 
@@ -62,24 +62,24 @@ namespace vfms
 
             // 'cd' command allows to enter and leave directories
             case cd:
-                exec_cd(this -> arguments, current_folder);
+                current_folder = exec_cd(this -> arguments, current_folder);
 
-                if(this -> arguments.size() == 2)
-                {
-                    vfms::vfs* temp = current_folder;
-                    temp = current_folder -> go_to(this -> arguments[1]);
+                // if(this -> arguments.size() == 2)
+                // {
+                //     vfms::vfs* temp = current_folder;
+                //     temp = current_folder -> go_to(this -> arguments[1]);
 
-                    // Only assign temp to current folder when there is no
-                    // error raised.
-                    if(temp != nullptr)
-                        current_folder = temp;
+                //     // Only assign temp to current folder when there is no
+                //     // error raised.
+                //     if(temp != nullptr)
+                //         current_folder = temp;
 
-                } else
-                {
-                    // Incorrect usage of cd. Raise an error.
-                    std::cerr << "Wrong use of command 'cd'.\n"
-                        "Usage: cd path/to/dir" << std::endl;                        
-                }
+                // } else
+                // {
+                //     // Incorrect usage of cd. Raise an error.
+                //     std::cerr << "Wrong use of command 'cd'.\n"
+                //         "Usage: cd path/to/dir" << std::endl;                        
+                // }
                 // Return back the current folder
                 return current_folder;
 


### PR DESCRIPTION
This PR adds `cd` functionality with options in vfms. Now the user can call `cd` with options like `--help`. Also, user can now `cd` for space separated directories.